### PR TITLE
fix: document count period filter (#882)

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { getRequiredServerComponentSession } from '@documenso/lib/next-auth/get-server-component-session';
+import type { PeriodSelectorValue } from '@documenso/lib/server-only/document/find-documents';
 import { findDocuments } from '@documenso/lib/server-only/document/find-documents';
 import { getStats } from '@documenso/lib/server-only/document/get-stats';
 import { isExtendedDocumentStatus } from '@documenso/prisma/guards/is-extended-document-status';
@@ -9,7 +10,6 @@ import { ExtendedDocumentStatus } from '@documenso/prisma/types/extended-documen
 import { Tabs, TabsList, TabsTrigger } from '@documenso/ui/primitives/tabs';
 
 import { PeriodSelector } from '~/components/(dashboard)/period-selector/period-selector';
-import type { PeriodSelectorValue } from '~/components/(dashboard)/period-selector/types';
 import { isPeriodSelectorValue } from '~/components/(dashboard)/period-selector/types';
 import { DocumentStatus } from '~/components/formatter/document-status';
 
@@ -32,14 +32,15 @@ export const metadata: Metadata = {
 export default async function DocumentsPage({ searchParams = {} }: DocumentsPageProps) {
   const { user } = await getRequiredServerComponentSession();
 
-  const stats = await getStats({
-    user,
-  });
-
   const status = isExtendedDocumentStatus(searchParams.status) ? searchParams.status : 'ALL';
   const period = isPeriodSelectorValue(searchParams.period) ? searchParams.period : '';
   const page = Number(searchParams.page) || 1;
   const perPage = Number(searchParams.perPage) || 20;
+
+  const stats = await getStats({
+    user,
+    period,
+  });
 
   const results = await findDocuments({
     userId: user.id,

--- a/apps/web/src/components/(dashboard)/period-selector/types.ts
+++ b/apps/web/src/components/(dashboard)/period-selector/types.ts
@@ -1,4 +1,4 @@
-export type PeriodSelectorValue = '' | '7d' | '14d' | '30d';
+import type { PeriodSelectorValue } from '@documenso/lib/server-only/document/find-documents';
 
 export const isPeriodSelectorValue = (value: unknown): value is PeriodSelectorValue => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/lib/server-only/document/find-documents.ts
+++ b/packages/lib/server-only/document/find-documents.ts
@@ -9,6 +9,8 @@ import { ExtendedDocumentStatus } from '@documenso/prisma/types/extended-documen
 import type { FindResultSet } from '../../types/find-result-set';
 import { maskRecipientTokensForDocument } from '../../utils/mask-recipient-tokens-for-document';
 
+export type PeriodSelectorValue = '' | '7d' | '14d' | '30d';
+
 export type FindDocumentsOptions = {
   userId: number;
   term?: string;
@@ -19,7 +21,7 @@ export type FindDocumentsOptions = {
     column: keyof Omit<Document, 'document'>;
     direction: 'asc' | 'desc';
   };
-  period?: '' | '7d' | '14d' | '30d';
+  period?: PeriodSelectorValue;
 };
 
 export const findDocuments = async ({


### PR DESCRIPTION
## Description

Currently the count for the documents table tabs do not display the correct values when the period filter is applied.

## Changes Made

- Updated `getStats` to support filtering on period

## Testing Performed

- Tested to see if the documents tab count were being filtered based on the period

## Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have followed the project's coding style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document search with period selection, allowing users to filter documents based on predefined time periods.
- **Refactor**
	- Improved type safety and code readability in document finding and statistics gathering functionalities by utilizing a shared `PeriodSelectorValue` type.
- **Chores**
	- Updated dependencies to include 'luxon' for better date and time handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->