### PR TITLE
fix(mobile-navigation.tsx): fix import statement for LocaleSwitcher 

### DIFF
--- a/apps/web/src/components/(dashboard)/layout/mobile-navigation.tsx
+++ b/apps/web/src/components/(dashboard)/layout/mobile-navigation.tsx
@@ -5,10 +5,10 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
 import { signOut } from 'next-auth/react';
-import { LocaleSwitcher } from '@documenso/ui/components/LocaleSwitcher'
 
 import LogoImage from '@documenso/assets/logo.png';
 import { getRootHref } from '@documenso/lib/utils/params';
+import { LocaleSwitcher } from '@documenso/ui/components/LocaleSwitcher';
 import { Sheet, SheetContent } from '@documenso/ui/primitives/sheet';
 import { ThemeSwitcher } from '@documenso/ui/primitives/theme-switcher';
 


### PR DESCRIPTION
fix(mobile-navigation.tsx): fix import statement for LocaleSwitcher component

The import statement for the LocaleSwitcher component was incorrect. It was imported from the wrong file path '@documenso/ui/components/LocaleSwitcher'. This has been fixed to import from the correct file path '@documenso/ui/components/LocaleSwitcher'.