### PR TITLE
feat(next.config.js): add support for generating a unique build ID ba…

### DIFF
--- a/apps/marketing/next.config.js
+++ b/apps/marketing/next.config.js
@@ -92,6 +92,10 @@ const config = {
       },
     ];
   },
+  generateBuildId: async () => {
+    // This could be anything, using the latest git hash
+    return process.env.VERSION || Date.now() + Math.round(Math.random() * 2441139);
+  },
 };
 
 module.exports = withContentlayer(config);

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -88,6 +88,10 @@ const config = {
       },
     ];
   },
+  generateBuildId: async () => {
+    // This could be anything, using the latest git hash
+    return process.env.VERSION || Date.now() + Math.round(Math.random() * 2441139);
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
feat(next.config.js): add support for generating a unique build ID based on the latest git hash or current timestamp to improve cache invalidation
The `next.config.js` file in both the `marketing` and `web` apps has been modified to include a `generateBuildId` function. This function generates a unique build ID that can be used for cache invalidation. The build ID is generated based on the latest git hash or the current timestamp if the `VERSION` environment variable is not set.

This change improves cache invalidation by ensuring that each build has a unique identifier.