### PR TITLE
feat(package.json): add build:marketing script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "build": "turbo run build",
     "build:web": "turbo run build --filter=@documenso/web",
+    "build:marketing": "turbo run build --filter=@documenso/marketing",
     "dev": "turbo run dev --filter=@documenso/marketing",
     "start:marketing": "turbo run start --filter=@documenso/marketing",
     "start:web": "turbo run start --filter=@documenso/web",


### PR DESCRIPTION
feat(package.json): add build:marketing script to build only the marketing module

The build:marketing script is added to the package.json file to allow building only the marketing module. This will provide a more efficient build process by excluding unnecessary modules.