### PR TITLE
feat(router): add healthRouter to appRouter to provide health check

### DIFF
--- a/packages/trpc/server/health-router/router.ts
+++ b/packages/trpc/server/health-router/router.ts
@@ -1,0 +1,10 @@
+import { TRPCError } from '@trpc/server';
+import { procedure, router } from '../trpc';
+import { z } from 'zod';
+
+export const healthRouter = router({
+  health: procedure
+    .query(() => {
+      return { status: 'ok' };
+    }),
+});

--- a/packages/trpc/server/router.ts
+++ b/packages/trpc/server/router.ts
@@ -3,6 +3,7 @@ import { authRouter } from './auth-router/router';
 import { cryptoRouter } from './crypto/router';
 import { documentRouter } from './document-router/router';
 import { fieldRouter } from './field-router/router';
+import { healthRouter } from './health-router/router';
 import { profileRouter } from './profile-router/router';
 import { recipientRouter } from './recipient-router/router';
 import { shareLinkRouter } from './share-link-router/router';
@@ -25,6 +26,7 @@ export const appRouter = router({
   team: teamRouter,
   template: templateRouter,
   twoFactorAuthentication: twoFactorAuthenticationRouter,
+  health: healthRouter
 });
 
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
feat(router): add healthRouter to appRouter to provide health check endpoint
A new file `health-router/router.ts` was added to the `packages/trpc/server` directory. This file contains a `healthRouter` that provides a health check endpoint. The endpoint returns a JSON object with a `status` property set to `'ok'`.

In the `router.ts` file, the `healthRouter` was imported and added to the `appRouter` as a new route. This allows the health check endpoint to be accessible through the main application router.

The purpose of this change is to provide a simple health check endpoint that can be used to monitor the status of the server.